### PR TITLE
case-sensitiveなファイルシステムでプロジェクト参照が失敗する問題の修正

### DIFF
--- a/EchoDotNetLiteSkstackIpBridge.Example/EchoDotNetLiteSkstackIpBridge.Example.csproj
+++ b/EchoDotNetLiteSkstackIpBridge.Example/EchoDotNetLiteSkstackIpBridge.Example.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EchoDotNetLite.Specifications\EchoDotNetLite.Specifications.csproj" />
-    <ProjectReference Include="..\EchoDotnetLiteSkstackIpBridge\EchoDotNetLiteSkstackIpBridge.csproj" />
+    <ProjectReference Include="..\EchoDotNetLiteSkstackIpBridge\EchoDotNetLiteSkstackIpBridge.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ubuntu 20.04上でEchoDotNetLiteSkstackIpBridge.Exampleをビルドしようとすると、ディレクトリEchoDot***n***etLiteSkstackIpBridgeが見つからず、失敗します。

プロジェクト参照のパスの大文字小文字を厳密に指定する(EchoDot***N***etLiteSkstackIpBridge)ことでこの問題が修正できます。

# 再現手順
```
$ cd EchoDotNetLiteSkstackIpBridge.Example/
$ dotnet build
.NET 向け Microsoft (R) Build Engine バージョン 16.10.2+857e5a733
Copyright (C) Microsoft Corporation.All rights reserved.

  復元対象のプロジェクトを決定しています...
  プロジェクト "/home/smdn/smdn-EchoDotNetLite/EchoDotnetLiteSkstackIpBridge/EchoDotNetLiteSkstackIpBridge.csproj" は見つからなかったためスキップします。
  プロジェクト "/home/smdn/smdn-EchoDotNetLite/EchoDotnetLiteSkstackIpBridge/EchoDotNetLiteSkstackIpBridge.csproj" は見つからなかったためスキップします。
  /home/smdn/smdn-EchoDotNetLite/EchoDotNetLite.Specifications/EchoDotNetLite.Specifications.csproj を復元しました (164 ms)。
  /home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge.Example/EchoDotNetLiteSkstackIpBridge.Example.csproj を復元しました (172 ms)。
  EchoDotNetLite.Specifications -> /home/smdn/smdn-EchoDotNetLite/EchoDotNetLite.Specifications/bin/Debug/netcoreapp2.1/EchoDotNetLite.Specifications.dll
    ︙
(以下省略)
    ︙
```

# 修正後の動作
```
$ dotnet build
.NET 向け Microsoft (R) Build Engine バージョン 16.10.2+857e5a733
Copyright (C) Microsoft Corporation.All rights reserved.

  復元対象のプロジェクトを決定しています...
  復元対象のすべてのプロジェクトは最新です。
  SkstackIpDotNet -> /home/smdn/smdn-EchoDotNetLite/SkstackIpDotNet/SkstackIpDotNet/bin/Debug/netcoreapp2.1/SkstackIpDotNet.dll
  EchoDotNetLite.Specifications -> /home/smdn/smdn-EchoDotNetLite/EchoDotNetLite.Specifications/bin/Debug/netcoreapp2.1/EchoDotNetLite.Specifications.dll
  EchoDotNetLite -> /home/smdn/smdn-EchoDotNetLite/EchoDotNetLite/bin/Debug/netcoreapp2.1/EchoDotNetLite.dll
  EchoDotNetLiteSkstackIpBridge -> /home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge/bin/Debug/netcoreapp2.1/EchoDotNetLiteSkstackIpBridge.dll
  EchoDotNetLiteSkstackIpBridge.Example -> /home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge.Example/bin/Debug/netcoreapp2.1/EchoDotNetLiteSkstackIpBridge.Example.dll

ビルドに成功しました。
    0 個の警告
    0 エラー

経過時間 00:00:01.57
```

# 環境情報
```
$ dotnet --info
.NET SDK (global.json を反映):
 Version:   5.0.302
 Commit:    c005824e35

ランタイム環境:
 OS Name:     ubuntu
 OS Version:  20.04
 OS Platform: Linux
 RID:         ubuntu.20.04-x64
 Base Path:   /usr/share/dotnet/sdk/5.0.302/

Host (useful for support):
  Version: 5.0.8
  Commit:  35964c9215

.NET SDKs installed:
  2.1.816 [/usr/share/dotnet/sdk]
  3.1.411 [/usr/share/dotnet/sdk]
  5.0.302 [/usr/share/dotnet/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.All 2.1.28 [/usr/share/dotnet/shared/Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.App 2.1.28 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 3.1.17 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 5.0.8 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 2.1.28 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
  Microsoft.NETCore.App 3.1.17 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
  Microsoft.NETCore.App 5.0.8 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```