### PR TITLE
エコーバックオフの場合、SKLL64のレスポンス待機で停止しないように修正

### DIFF
--- a/SkstackIpDotNet/SkstackIpDotNet/Commands/SKLl64Command.cs
+++ b/SkstackIpDotNet/SkstackIpDotNet/Commands/SKLl64Command.cs
@@ -1,4 +1,5 @@
 ﻿using SkstackIpDotNet.Responses;
+using System.Net;
 using System.Text;
 
 namespace SkstackIpDotNet.Commands
@@ -38,6 +39,11 @@ namespace SkstackIpDotNet.Commands
             if (HasEchoback)
             {
                 //エコーバックの次に、<IPADDR><CRLF>が来る
+                TaskCompletionSource.SetResult(new SKLL64(eventRow));
+            }
+            else if (IPAddress.TryParse(eventRow, out _))
+            {
+                //エコーバックが無い場合で、<IPADDR><CRLF>として解釈できる行の場合は、それをもって結果を確定する
                 TaskCompletionSource.SetResult(new SKLL64(eventRow));
             }
             base.ReceiveHandler(sendor, eventRow);


### PR DESCRIPTION
# 事象
ROHM BP35A1で実行した場合、かつエコーバックの設定がオフの場合、レスポンスを無限に待機してハングアップが発生します。

# 原因
ROHM BP35A1ではレジスタ設定でエコーバックをオフにすることができます。

一方、コマンド`SKLL64`はOK/FAILのステータス行なしでコマンドを終了すると規定されていて、かつ現在の実装ではエコーバック行の受信を前提としているため、エコーバックが無いと無限に待機する動作となっています。

そこで、`<IPADDR><CRLF>`として解釈できる行を受信した場合は、それをもってレスポンス解析終了とすることで、ハングアップを回避できます。

# 現在の動作
```
    ︙
(途中省略)
    ︙
dbug: EchoDotNetLiteSkstackIpBridge.SkstackIpPANAClient[0]
      PAN発見: 論理チャンネル番号:XX,チャンネルページ:XX,PAN ID:XXXX,アドレス:XXXXXXXXXXXXXXXX,RSSI:9B,PairingID:XXXXXXXX
trce: SkstackIpDotNet.SKDevice[0]
      >>SKSREG S2 XX
      
trce: SkstackIpDotNet.SKDevice[0]
      <<OK
trce: SkstackIpDotNet.SKDevice[0]
      >>SKSREG S3 XXXX
      
trce: SkstackIpDotNet.SKDevice[0]
      <<OK
trce: SkstackIpDotNet.SKDevice[0]
      >>SKLL64 XXXXXXXXXXXXXXXX
      
trce: SkstackIpDotNet.SKDevice[0]
      <<FE80:0000:0000:0000:XXXX:XXXX:XXXX:XXXX
trce: SkstackIpDotNet.SKDevice[0]
      <<EVENT 20 FE80:0000:0000:0000:XXXX:XXXX:XXXX:XXXX
trce: SkstackIpDotNet.SKDevice[0]
      <<EPANDESC
trce: SkstackIpDotNet.SKDevice[0]
      <<  Channel:XX
trce: SkstackIpDotNet.SKDevice[0]
      <<  Channel Page:XX
trce: SkstackIpDotNet.SKDevice[0]
      <<  Pan ID:XXXX
trce: SkstackIpDotNet.SKDevice[0]
      <<  Addr:XXXXXXXXXXXXXXXX
trce: SkstackIpDotNet.SKDevice[0]
      <<  LQI:9C
trce: SkstackIpDotNet.SKDevice[0]
      <<  PairID:XXXXXXXX
trce: SkstackIpDotNet.SKDevice[0]
      <<EVENT 22 FE80:0000:0000:0000:XXXX:XXXX:XXXX:XXXX
fail: EchoDotNetLiteSkstackIpBridge.Example.Example[0]
      AggregateException
System.AggregateException: One or more errors occurred. (Timeout has expired) ---> System.TimeoutException: Timeout has expired
   at SkstackIpDotNet.SKDevice.ExecuteSKCommandAsync[TResponse](AbstractSKCommand`1 command) in /home/smdn/smdn-EchoDotNetLite/SkstackIpDotNet/SkstackIpDotNet/SKDevice.cs:line 185
   at SkstackIpDotNet.SKDevice.SKLl64Async(String addr64) in /home/smdn/smdn-EchoDotNetLite/SkstackIpDotNet/SkstackIpDotNet/SKDevice.cs:line 313
   at EchoDotNetLiteSkstackIpBridge.SkstackIpPANAClient.ScanAndJoinAsync(String bRouteId, String bRoutePassword) in /home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge/SkstackIpPANAClient.cs:line 67
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at EchoDotNetLiteSkstackIpBridge.Example.Program.Main(String[] args) in /home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge.Example/Program.cs:line 75
---> (Inner Exception #0) System.TimeoutException: Timeout has expired
   at SkstackIpDotNet.SKDevice.ExecuteSKCommandAsync[TResponse](AbstractSKCommand`1 command) in /home/smdn/smdn-EchoDotNetLite/SkstackIpDotNet/SkstackIpDotNet/SKDevice.cs:line 185
   at SkstackIpDotNet.SKDevice.SKLl64Async(String addr64) in /home/smdn/smdn-EchoDotNetLite/SkstackIpDotNet/SkstackIpDotNet/SKDevice.cs:line 313
   at EchoDotNetLiteSkstackIpBridge.SkstackIpPANAClient.ScanAndJoinAsync(String bRouteId, String bRoutePassword) in /home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge/SkstackIpPANAClient.cs:line 67<---
```


# 修正後の動作(期待する動作)
```
dbug: EchoDotNetLiteSkstackIpBridge.SkstackIpPANAClient[0]
      PAN発見: 論理チャンネル番号:XX,チャンネルページ:XX,PAN ID:XXXX,アドレス:XXXXXXXXXXXXXXXX,RSSI:98,PairingID:XXXXXXXX
trce: SkstackIpDotNet.SKDevice[0]
      >>SKSREG S2 XX
      
trce: SkstackIpDotNet.SKDevice[0]
      <<OK
trce: SkstackIpDotNet.SKDevice[0]
      >>SKSREG S3 XXXX
      
trce: SkstackIpDotNet.SKDevice[0]
      <<OK
trce: SkstackIpDotNet.SKDevice[0]
      >>SKLL64 XXXXXXXXXXXXXXXX
      
trce: SkstackIpDotNet.SKDevice[0]
      <<FE80:0000:0000:0000:XXXX:XXXX:XXXX:XXXX
dbug: EchoDotNetLiteSkstackIpBridge.SkstackIpPANAClient[0]
      PANA接続シーケンス開始
trce: SkstackIpDotNet.SKDevice[0]
      >>SKJOIN FE80:0000:0000:0000:XXXX:XXXX:XXXX:XXXX
      
trce: SkstackIpDotNet.SKDevice[0]
      <<OK
    ︙
(以降省略)
    ︙
```
