### PR TITLE
EchoDotNetLite.Specifications/MasterDataディレクトリパス解決の改善

### DIFF
--- a/EchoDotNetLite.Specifications/EchonetObject.cs
+++ b/EchoDotNetLite.Specifications/EchonetObject.cs
@@ -20,7 +20,7 @@ namespace EchoDotNetLite.Specifications
             {
                 //スーパークラスのプロパティを列挙
                 
-                var superClassFilePath = Path.Combine(Directory.GetCurrentDirectory(), "MasterData", $"{ClassGroup.SuperClass}.json");
+                var superClassFilePath = Path.Combine(SpecificationMaster.GetSpecificationMasterDataDirectory(), $"{ClassGroup.SuperClass}.json");
                 if (File.Exists(superClassFilePath))
                 {
                     var superClassProperties = JsonConvert.DeserializeObject<PropertyMaster>(File.ReadAllText(superClassFilePath, new UTF8Encoding(false)));
@@ -29,7 +29,7 @@ namespace EchoDotNetLite.Specifications
                 Class = ClassGroup.ClassList.Where(c => c.Status && c.ClassCode == classCode).FirstOrDefault();
                 if (Class.Status)
                 {
-                    var classFilePath = Path.Combine(Directory.GetCurrentDirectory(), "MasterData",$"0x{ClassGroup.ClassGroupCode:X2}-{ClassGroup.ClassGroupName}", $"0x{Class.ClassCode:X2}-{Class.ClassName}.json");
+                    var classFilePath = Path.Combine(SpecificationMaster.GetSpecificationMasterDataDirectory(),$"0x{ClassGroup.ClassGroupCode:X2}-{ClassGroup.ClassGroupName}", $"0x{Class.ClassCode:X2}-{Class.ClassName}.json");
                     if (File.Exists(classFilePath))
                     {
                         //クラスのプロパティを列挙

--- a/EchoDotNetLite.Specifications/SpecificationMaster.cs
+++ b/EchoDotNetLite.Specifications/SpecificationMaster.cs
@@ -30,10 +30,17 @@ namespace EchoDotNetLite.Specifications
         {
             if (_Instance == null)
             {
-                var filePath = Path.Combine(Directory.GetCurrentDirectory(), "MasterData", "SpecificationMaster.json");
+                var filePath = Path.Combine(GetSpecificationMasterDataDirectory(), "SpecificationMaster.json");
                 _Instance = JsonConvert.DeserializeObject<SpecificationMaster>(File.ReadAllText(filePath, new UTF8Encoding(false)));
             }
             return _Instance;
+        }
+
+        internal static string GetSpecificationMasterDataDirectory()
+        {
+            var assemblyLocatedDirectory = Path.GetDirectoryName(typeof(SpecificationMaster).Assembly.Location);
+
+            return Path.Combine(assemblyLocatedDirectory, "MasterData");
         }
 
         /// <summary>


### PR DESCRIPTION
# 事象
実行時のカレントディレクトリがアセンブリ`EchoDotNetLite.Specifications.dll`の位置と異なる場合、ディレクトリ`EchoDotNetLite.Specifications/MasterData`を見つけられず、`DirectoryNotFoundException`をラップした`TypeInitializationException`がスローされます。

# 原因
現在の実装ではディレクトリ`EchoDotNetLite.Specifications/MasterData`を、カレントディレクトリを基準にして探索しています。
この実装では、カレントディレクトリが暗黙的にアセンブリの出力ディレクトリと同じであることを期待しているため、カレントディレクトリが左記と異なるディレクトリに設定されている状態で実行すると、パス探索に失敗し、`DirectoryNotFoundException`となります。

例えば`dotnet run`コマンド等で実行した場合、カレントディレクトリは`dotnet run`コマンドを実行したディレクトリとなり、本事象が発生します。

そこで、カレントディレクトリではなく、アセンブリの配置されているディレクトリを元にパスを解決することで、この問題を修正できます。

# 現在の動作
```
$ pwd
/home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge.Example

$ tree -d .
.
├── bin
│   └── Debug
│       └── netcoreapp2.1
│           └── MasterData
│               ├── 0x00-センサ関連機器
│               ├── 0x01-空調関連機器
│               ├── 0x02-住宅設備関連機器
│               ├── 0x03-調理家事関連機器
│               ├── 0x04-健康関連機器
│               ├── 0x05-管理操作関連機器
│               ├── 0x06-ＡＶ関連機器
│               └── 0x0E-プロファイル
└── obj
    └── Debug
        └── netcoreapp2.1

15 directories

$ dotnet run
    ︙
(途中省略)
    ︙
trce: SkstackIpDotNet.SKDevice[0]
      <<EVENT 25 FE80:0000:0000:0000:XXXX:XXXX:XXXX:XXXX
dbug: EchoDotNetLiteSkstackIpBridge.SkstackIpPANAClient[0]
      0x25:PANA による接続が完了した
fail: EchoDotNetLiteSkstackIpBridge.Example.Example[0]
      Exception
System.TypeInitializationException: The type initializer for 'EchoDotNetLite.Specifications.プロファイル' threw an exception. ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge.Example/MasterData/SpecificationMaster.json'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at System.IO.StreamReader..ctor(String path, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize)
   at System.IO.File.InternalReadAllText(String path, Encoding encoding)
   at System.IO.File.ReadAllText(String path, Encoding encoding)
   at EchoDotNetLite.Specifications.SpecificationMaster.GetInstance() in /home/smdn/smdn-EchoDotNetLite/EchoDotNetLite.Specifications/SpecificationMaster.cs:line 34
   at EchoDotNetLite.Specifications.EchonetObject..ctor(Byte classGroupCode, Byte classCode) in /home/smdn/smdn-EchoDotNetLite/EchoDotNetLite.Specifications/EchonetObject.cs:line 14
   at EchoDotNetLite.Specifications.プロファイル..cctor() in /home/smdn/smdn-EchoDotNetLite/EchoDotNetLite.Specifications/プロファイル.cs:line 14
   --- End of inner exception stack trace ---
   at EchoDotNetLite.EchoClient..ctor(ILogger`1 logger, IPANAClient panaClient) in /home/smdn/smdn-EchoDotNetLite/EchoDotNetLite/Client.cs:line 24
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, ServiceProviderEngineScope scope)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScoped(ScopedCallSite scopedCallSite, ServiceProviderEngineScope scope)
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService[T](IServiceProvider provider)
   at EchoDotNetLiteSkstackIpBridge.Example.Program.Main(String[] args) in /home/smdn/smdn-EchoDotNetLite/EchoDotNetLiteSkstackIpBridge.Example/Program.cs:line 77
trce: SkstackIpDotNet.SKDevice[0]
      Close
```

# 修正後の動作(期待する動作)
```
$ dotnet run
    ︙
(途中省略)
    ︙
trce: SkstackIpDotNet.SKDevice[0]
      <<EVENT 25 FE80:0000:0000:0000:XXXX:XXXX:XXXX:XXXX
dbug: EchoDotNetLiteSkstackIpBridge.SkstackIpPANAClient[0]
      0x25:PANA による接続が完了した
trce: EchoDotNetLite.EchoClient[0]
      Echonet Lite Frame送信: address:
    ︙
(途中省略)
    ︙
trce: EchoDotNetLite.EchoClient[0]
      0x02住宅設備関連機器 0x88低圧スマート電力量メータ 01 プロパティマップの読み取りが成功しました
    ︙
(以降省略)
    ︙
```
