### PR TITLE
提案: RJCP.IO.PortsからSystem.IO.Portsへの置き換え

### DIFF
--- a/EchoDotNetLiteSkstackIpBridge.Example/Program.cs
+++ b/EchoDotNetLiteSkstackIpBridge.Example/Program.cs
@@ -5,9 +5,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using RJCP.IO.Ports;
 using SkstackIpDotNet;
 using System;
+using System.IO.Ports;
 using System.Threading.Tasks;
 
 namespace EchoDotNetLiteSkstackIpBridge.Example

--- a/EchoDotNetLiteSkstackIpBridge/SkstackIpPANAClient.cs
+++ b/EchoDotNetLiteSkstackIpBridge/SkstackIpPANAClient.cs
@@ -1,11 +1,11 @@
 ﻿using EchoDotNetLite;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using RJCP.IO.Ports;
 using SkstackIpDotNet;
 using SkstackIpDotNet.Events;
 using System;
 using System.Collections.Generic;
+using System.IO.Ports;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ ECHONET Liteやその周辺の規格/仕様を.Net Core 2.1で実装したもの
 * 機器オブジェクトエミュレーター:[MoekadenRoom](https://github.com/SonyCSL/MoekadenRoom/blob/master/README.jp.md)
 * 低圧スマート電力量メータ:中部電力管内(2機)
 
-# 依存関係
-* シリアルポートの処理に[SerialPortStream](https://github.com/jcurl/SerialPortStream)を使用しています。
-* Linux上で動作させる場合、[こちら](https://github.com/jcurl/SerialPortStream#linux)に記載の通り、サポート・ライブラリー`libnserial.so`をコンパイルする必要があります
-
 # 参考情報
 * [HEMS-スマートメーターBルート(低圧電力メーター)運用ガイドライン第4.0版](http://www.meti.go.jp/committee/kenkyukai/shoujo/smart_house/pdf/009_s03_00.pdf)
 * [エコーネット規格　（一般公開）](https://echonet.jp/spec_g/)

--- a/SkstackIpDotNet/README.md
+++ b/SkstackIpDotNet/README.md
@@ -6,10 +6,6 @@ SKSTACK IP .NET Library
   Wi-SUN Route-B 専用 [RL7023 Stick-D/IPS](https://www.tessera.co.jp/rl7023stick-d_ips.html)
 * OS:Windows10/Raspbian Stretch
 
-# 依存関係
-* シリアルポートの処理に[SerialPortStream](https://github.com/jcurl/SerialPortStream)を使用しています。
-* Linux上で動作させる場合、[こちら](https://github.com/jcurl/SerialPortStream#linux)に記載の通り、サポート・ライブラリー`libnserial.so`をコンパイルする必要があります
-
 # 実装状況
 * RL7023 Stick-D/IPSに付属のSKコマンドリファレンスマニュアル
 `SKSTACK-IP(Single-hop Edition) Version 1.2.1a`をもとに全コマンド実装

--- a/SkstackIpDotNet/SkstackIpDotNet.Example/Program.cs
+++ b/SkstackIpDotNet/SkstackIpDotNet.Example/Program.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using RJCP.IO.Ports;
 using System;
+using System.IO.Ports;
 using System.Threading.Tasks;
 
 namespace SkstackIpDotNet.Example

--- a/SkstackIpDotNet/SkstackIpDotNet/SkstackIpDotNet.csproj
+++ b/SkstackIpDotNet/SkstackIpDotNet/SkstackIpDotNet.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="SerialPortStream" Version="2.1.4" />
+    <PackageReference Include="System.IO.Ports" Version="5.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
現在、シリアルポートの処理に[System.IO.Ports.SerialPort](https://docs.microsoft.com/ja-jp/dotnet/api/system.io.ports.serialport)を使用することができます。

System.IO.Portsを使用することにより、別途`libnserial.so`をビルド・インストールをする手順を減らすことができる点、またSystem.IO.PortsはMicrosoftがメンテナンスしているパッケージである点から、利便性・メンテナンスの継続性の面でメリットがあると考えられるため、System.IO.Portsへの置き換えを提案します。

System.IO.Portsは.NET Core 2.1以降をサポートしているため、大幅な変更なく置き換えることができます。

なお、当方では、Ubuntu 20.04およびROHM BP35A1で動作することを確認しています。