### PR TITLE
ESV=SetGet等においてOPCGetが正しくデシリアライズされない問題の修正

### DIFF
--- a/EchoDotNetLite/FrameSerializer.cs
+++ b/EchoDotNetLite/FrameSerializer.cs
@@ -112,7 +112,7 @@ namespace EchoDotNetLite
                 // OPCGet 処理プロパティ数(1B)
                 var opcGet = br.ReadByte();
                 edata.OPCGetList = new List<PropertyRequest>();
-                for (int i = 0; i < opcSet; i++)
+                for (int i = 0; i < opcGet; i++)
                 {
                     var prp = new PropertyRequest
                     {


### PR DESCRIPTION
# 事象
ESVがSetGet等の、OPCSetとOPCGetの両方が含まれるフレームデータについて、OPCGetの値、およびそれ以降のデータが正しくデシリアライズされない。

## 再現コード
以下のコードで状況を再現できます。

```csharp
// ESV=SetGet, OPCSet=1, OPCGet=2のフレームデータを作成
var frameBytes = new byte[] {
  0x10, // EDH1 (ECHONETLite)
  0x81, // EDH2 (Type1)
  0x00, 0x00, // TID (0x0000)
  0x00, 0x00, 0x00, // SEOJ (0x00-0x00-0x00)
  0x00, 0x00, 0x00, // DEOJ (0x00-0x00-0x00)
  0x6E, // ESV (SetGet)
  0x01, // OPCSet (1)
    0xF0, // EPC #1 (0xF0)
      0x01, // PDC #1 (1)
      0x00, // EDT #1 [0]
  0x02, // OPCGet (2)
    0xF1, // EPC #1 (0xF1)
      0x01, // PDC #1 (1)
      0x00, // EDT #1 [0]
    0xF2, // EPC #2 (0xF1)
      0x01, // PDC #2 (1)
      0x00, // EDT #2 [0]
};

// 上記フレームデータをデシリアライズ
var frame = FrameSerializer.Deserialize(frameBytes);

// OPCSet・OPCGetとしてデシリアライズされたプロパティの数を表示
Console.WriteLine($"OPCSet: {(frame.EDATA as EDATA1).OPCSetList.Count}");
Console.WriteLine($"OPCGet: {(frame.EDATA as EDATA1).OPCGetList.Count}");
```

### 期待される動作
```
OPCSet: 1
OPCGet: 2
```

### 現在の動作
```
OPCSet: 1
OPCGet: 1
```

`OPCGet 2`となるべきところ、`OPCGet 1`となっている。

# 原因と対処
`FrameSerializer.EDATA1FromBytes`において、読み取り処理対象プロパティの数としてOPCGetの値を参照すべきところ、誤ってOPCSetの値を参照しています。

したがって、読み取り処理対象プロパティの数としてOPCGetの値を参照することでこの不具合を修正できます。