### PR TITLE
EchoClientのプロパティ値書き込み/読み出しにて、DEOJがある/ない場合の動作が逆転する不具合の修正

### DIFF
--- a/EchoDotNetLite/Client.cs
+++ b/EchoDotNetLite/Client.cs
@@ -918,7 +918,7 @@ namespace EchoDotNetLite
         {
             bool hasError = false;
             var opcList = new List<PropertyRequest>();
-            if (destObject != null)
+            if (destObject == null)
             {
                 //DEOJがない場合、全OPCをそのまま返す
                 hasError = true;
@@ -992,7 +992,7 @@ namespace EchoDotNetLite
         {
             bool hasError = false;
             var opcList = new List<PropertyRequest>();
-            if (destObject != null)
+            if (destObject == null)
             {
                 //DEOJがない場合、全OPCをそのまま返す
                 hasError = true;
@@ -1068,7 +1068,7 @@ namespace EchoDotNetLite
             bool hasError = false;
             var opcSetList = new List<PropertyRequest>();
             var opcGetList = new List<PropertyRequest>();
-            if (destObject != null)
+            if (destObject == null)
             {
                 //DEOJがない場合、全OPCをそのまま返す
                 hasError = true;


### PR DESCRIPTION
# 事象
EchoClientクラスの下記メソッドにおいて、「DEOJがある/ない場合」の条件式と動作が逆転しているため、コードが本来意図しているとおりに動作しません。
- `EchoClient.プロパティ値書き込みサービス応答要`
- `EchoClient.プロパティ値読み出しサービス`
- `EchoClient.プロパティ値書き込み読み出しサービス`

## 詳細
上記メソッドにおいて、「DEOJがない場合」へ分岐するための条件式が`if (destObject != null)`となっています。
これにより、コードが本来意図している動作とは逆となる分岐が起こります。
またこれに従い、`destObject`が`null`の場合、`destObject`を参照しようとして`NullReferenceException`がスローされます。

## 再現コード
コード精査中に発見した問題であるため、この問題を発現させるコードは未作成です。

# 対処
「DEOJがない場合」へ分岐するための条件式を以下のように修正します。

```diff
-if (destObject != null)
+if (destObject == null)
 {
      //DEOJがない場合、全OPCをそのまま返す
```
